### PR TITLE
Add easy start scripts and instructions for non-developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,21 @@ A simple web calendar showing Telugu Panchangam details for 2025. Use the drop-d
 
 Each month also has its own page under the `*.html` files.
 
-The app fetches details from `https://telugu-calendar-live.onrender.com/panchang`.  
+The app fetches details from `https://telugu-calendar-live.onrender.com/panchang`.
 If that service is unavailable, it falls back to a small bundled `panchangam_2025.json` file for demo data and shows an error when neither source is reachable.
+
+## Quick start (no coding required)
+
+1. Click the green **Code** button on GitHub and choose **Download ZIP**.
+2. Unzip the folder somewhere easy to find (for example, your Desktop).
+3. Open the unzipped folder and double-click the start file for your computer:
+   - **Windows:** `start-server.bat`
+   - **macOS:** `start-server.command`
+   - **Linux:** run `start-server.sh`
+4. A terminal window will open and show messages from a small web server. Leave it running.
+5. Open your web browser and go to <http://localhost:8000>. The Telugu calendar will load automatically.
+6. When you are finished, close the browser tab and return to the terminal window to press **Ctrl + C** (or simply close the window) to stop the server.
+
+> **Note:** These start scripts use Python, which is already installed on macOS and most Linux computers. On Windows you may need to install Python from [python.org](https://www.python.org/downloads/) first. During the installer, make sure you tick **Add python.exe to PATH**.
+
+If you prefer to start the server manually (for example, on another port), you can run `python3 -m http.server 8000` from the project folder and open <http://localhost:8000> in your browser. Any static file server (such as VS Code’s Live Server extension or `npx serve`) will also work.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ If that service is unavailable, it falls back to a small bundled `panchangam_202
 
 ## Quick start (no coding required)
 
-1. Open this project on GitHub in your web browser. In the upper-right corner of the file list you will see a green **Code** button—click it and choose **Download ZIP**.
-2. Unzip the folder somewhere easy to find (for example, your Desktop).
-3. Open the unzipped folder and double-click the start file for your computer:
-   - **Windows:** `start-server.bat`
-   - **macOS:** `start-server.command`
-   - **Linux:** run `start-server.sh`
-4. A terminal window will open and show messages from a small web server. Leave it running.
-5. Open your web browser and go to <http://localhost:8000>. The Telugu calendar will load automatically.
-6. When you are finished, close the browser tab and return to the terminal window to press **Ctrl + C** (or simply close the window) to stop the server.
+Follow these steps exactly in order, even if you have never used GitHub before:
+
+1. **Open the project page on GitHub.** Launch your web browser (Chrome, Edge, Safari, etc.) and go to the repository URL your developer shared with you. You should see a list of files and folders.
+2. **Download everything in one click.** Look above the file list, near the upper-right corner of the page, for the green **Code** button. Click it, choose **Download ZIP**, and the browser will save a file named similar to `telugu-calendar-2025-main.zip`.
+3. **Unzip the download.** Open your Downloads folder, right-click the ZIP file, and choose **Extract** (Windows) or double-click it (macOS). A new folder with the same name will appear once extraction is finished.
+4. **Open the extracted folder.** Inside you will find the project files plus three “start server” helpers.
+5. **Start the calendar with the script that matches your computer:**
+   - On **Windows**, double-click `start-server.bat`. If Windows warns you, choose **More info** → **Run anyway**.
+   - On **macOS**, double-click `start-server.command`. You may need to approve it in **System Settings → Privacy & Security** the first time.
+   - On **Linux**, right-click in the folder, choose **Open in Terminal**, and run `./start-server.sh`.
+6. **Leave the terminal window open.** A black window (Command Prompt or Terminal) will appear showing lines like “Serving HTTP on…”. Do not close it.
+7. **Open the calendar in your browser.** Type <http://localhost:8000> into the browser’s address bar and press **Enter**. The Telugu calendar home page will load.
+8. **Stop when you are done.** Close the browser tab. Go back to the terminal window and press **Ctrl + C** (or close the window) to shut down the server.
 
 > **Note:** These start scripts use Python, which is already installed on macOS and most Linux computers. On Windows you may need to install Python from [python.org](https://www.python.org/downloads/) first. During the installer, make sure you tick **Add python.exe to PATH**.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If that service is unavailable, it falls back to a small bundled `panchangam_202
 
 ## Quick start (no coding required)
 
-1. Click the green **Code** button on GitHub and choose **Download ZIP**.
+1. Open this project on GitHub in your web browser. In the upper-right corner of the file list you will see a green **Code** button—click it and choose **Download ZIP**.
 2. Unzip the folder somewhere easy to find (for example, your Desktop).
 3. Open the unzipped folder and double-click the start file for your computer:
    - **Windows:** `start-server.bat`

--- a/index.html
+++ b/index.html
@@ -1,18 +1,57 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mana Telugu Panchangam 2025</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Mana Telugu Panchangam 2025</h1>
-  <label for="citySelect">Choose a city:</label>
-  <select id="citySelect"></select>
-  <div id="calendar"></div>
-  <div id="details"></div>
+  <header class="hero">
+    <div class="hero__content">
+      <h1>Mana Telugu Panchangam 2025</h1>
+      <p>Daily tithi, nakshatram, rahu kalam timings and festival highlights inspired by the Prokerala layout.</p>
+    </div>
+    <div class="hero__controls">
+      <label for="citySelect" class="visually-hidden">Choose a city</label>
+      <select id="citySelect" class="control"></select>
+      <div class="month-nav">
+        <button id="prevMonth" aria-label="Previous month">&#9664;</button>
+        <div>
+          <h2 id="monthLabel"></h2>
+          <span id="timezoneLabel"></span>
+        </div>
+        <button id="nextMonth" aria-label="Next month">&#9654;</button>
+      </div>
+      <button id="todayBtn" class="control">Today</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="calendar-panel" aria-live="polite">
+      <div class="legend">
+        <span class="legend__item"><span class="dot dot--today"></span> Today</span>
+        <span class="legend__item"><span class="dot dot--festival"></span> Festival</span>
+      </div>
+      <div id="calendar" class="calendar"></div>
+    </section>
+
+    <aside class="info-panel">
+      <article id="details" class="card">
+        <h3>Select a date</h3>
+        <p>The Panchangam details for the chosen date appear here.</p>
+      </article>
+      <article class="card" id="festivalCard">
+        <h3>Festival Highlights</h3>
+        <ul id="festivalList"></ul>
+      </article>
+    </aside>
+  </main>
+
+  <footer class="footer">
+    <p>Data is fetched live when available and falls back to the bundled Panchangam dataset.</p>
+  </footer>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,69 +1,286 @@
+const API_URL = "https://telugu-calendar-live.onrender.com/panchang";
+const LOCAL_DATA_URL = "panchangam_2025.json";
+const BASE_YEAR = 2025;
 
 const cities = {
-  "Hyderabad": { lat: 17.385, lon: 78.4867, tz: 5.5 },
-  "Chennai": { lat: 13.0827, lon: 80.2707, tz: 5.5 },
-  "Bangalore": { lat: 12.9716, lon: 77.5946, tz: 5.5 },
-  "Kerala": { lat: 9.9312, lon: 76.2673, tz: 5.5 },
-  "London": { lat: 51.5074, lon: -0.1278, tz: 0 },
-  "Toronto": { lat: 43.6532, lon: -79.3832, tz: -5 },
-  "California": { lat: 34.0522, lon: -118.2437, tz: -8 }
+  Hyderabad: { lat: 17.385, lon: 78.4867, tz: 5.5 },
+  Chennai: { lat: 13.0827, lon: 80.2707, tz: 5.5 },
+  Bangalore: { lat: 12.9716, lon: 77.5946, tz: 5.5 },
+  Visakhapatnam: { lat: 17.6868, lon: 83.2185, tz: 5.5 },
+  Vijayawada: { lat: 16.5062, lon: 80.648, tz: 5.5 },
+  Kerala: { lat: 9.9312, lon: 76.2673, tz: 5.5 },
+  London: { lat: 51.5074, lon: -0.1278, tz: 0 },
+  Toronto: { lat: 43.6532, lon: -79.3832, tz: -5 },
+  California: { lat: 34.0522, lon: -118.2437, tz: -8 }
+};
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+];
+
+const festivalData = {
+  "01-01-2025": ["English New Year"],
+  "14-01-2025": ["Bhogi"],
+  "15-01-2025": ["Makara Sankranti"],
+  "16-01-2025": ["Kanuma"],
+  "26-01-2025": ["Republic Day"],
+  "13-02-2025": ["Ratha Saptami"],
+  "28-02-2025": ["Maha Shivaratri"],
+  "17-03-2025": ["Ugadi"],
+  "25-03-2025": ["Sri Rama Navami"],
+  "12-04-2025": ["Hanuman Jayanti"],
+  "08-05-2025": ["Akshaya Tritiya"],
+  "05-06-2025": ["Narasimha Jayanti"],
+  "15-08-2025": ["Independence Day"],
+  "16-09-2025": ["Vinayaka Chavithi"],
+  "02-10-2025": ["Gandhi Jayanti"],
+  "21-10-2025": ["Mahalaya Amavasya"],
+  "30-10-2025": ["Diwali"],
+  "31-10-2025": ["Balipadyami"],
+  "20-11-2025": ["Kartika Purnima"],
+  "25-12-2025": ["Subh Christmas"],
+  "31-12-2025": ["Vaikunta Ekadasi"]
 };
 
 let selectedCity = "Hyderabad";
+let currentMonth = 0;
+let localPanchangam = {};
+let localDataReady = false;
 
-window.onload = () => {
-  const citySelect = document.getElementById("citySelect");
-  for (const city in cities) {
-    const option = document.createElement("option");
-    option.value = city;
-    option.textContent = city;
-    citySelect.appendChild(option);
-  }
-  citySelect.value = selectedCity;
-  citySelect.addEventListener("change", () => {
-    selectedCity = citySelect.value;
-    loadCalendar(2025);
-  });
-  loadCalendar(2025);
-};
+const today = new Date();
+if (today.getFullYear() === BASE_YEAR) {
+  currentMonth = today.getMonth();
+}
 
-function loadCalendar(year) {
-  const calendar = document.getElementById("calendar");
-  calendar.innerHTML = "";
-  for (let m = 0; m < 12; m++) {
-    const monthDiv = document.createElement("div");
-    monthDiv.innerHTML = `<h2>${new Date(year, m).toLocaleString('default', { month: 'long' })}</h2>`;
-    for (let d = 1; d <= 31; d++) {
-      const date = new Date(year, m, d);
-      if (date.getMonth() !== m) break;
-      const btn = document.createElement("button");
-      btn.textContent = d;
-      btn.onclick = () => showDetails(d, m + 1, year);
-      monthDiv.appendChild(btn);
-    }
-    calendar.appendChild(monthDiv);
+const citySelectEl = document.getElementById("citySelect");
+const calendarEl = document.getElementById("calendar");
+const detailsEl = document.getElementById("details");
+const festivalListEl = document.getElementById("festivalList");
+const monthLabelEl = document.getElementById("monthLabel");
+const timezoneLabelEl = document.getElementById("timezoneLabel");
+const prevMonthBtn = document.getElementById("prevMonth");
+const nextMonthBtn = document.getElementById("nextMonth");
+const todayBtn = document.getElementById("todayBtn");
+
+function init() {
+  populateCities();
+  attachEventHandlers();
+  prefetchLocalData();
+  renderCalendar(BASE_YEAR, currentMonth);
+  if (today.getFullYear() === BASE_YEAR) {
+    showDetails(today.getDate(), today.getMonth() + 1, BASE_YEAR);
   }
 }
 
-const API_URL = "https://telugu-calendar-live.onrender.com/panchang";
-const LOCAL_DATA_URL = "panchangam_2025.json";
+function populateCities() {
+  for (const city of Object.keys(cities)) {
+    const option = document.createElement("option");
+    option.value = city;
+    option.textContent = city;
+    citySelectEl.appendChild(option);
+  }
+  citySelectEl.value = selectedCity;
+  updateTimezoneLabel();
+}
+
+function attachEventHandlers() {
+  citySelectEl.addEventListener("change", () => {
+    selectedCity = citySelectEl.value;
+    updateTimezoneLabel();
+    renderCalendar(BASE_YEAR, currentMonth);
+  });
+
+  prevMonthBtn.addEventListener("click", () => changeMonth(-1));
+  nextMonthBtn.addEventListener("click", () => changeMonth(1));
+  todayBtn.addEventListener("click", () => {
+    if (today.getFullYear() === BASE_YEAR) {
+      currentMonth = today.getMonth();
+      renderCalendar(BASE_YEAR, currentMonth);
+      showDetails(today.getDate(), today.getMonth() + 1, BASE_YEAR);
+    } else {
+      currentMonth = 0;
+      renderCalendar(BASE_YEAR, currentMonth);
+      detailsEl.innerHTML = `<h3>${MONTHS[currentMonth]} ${BASE_YEAR}</h3><p>Today's Panchangam is available only for 2025 in this demo.</p>`;
+    }
+  });
+}
+
+function changeMonth(delta) {
+  currentMonth = (currentMonth + delta + 12) % 12;
+  renderCalendar(BASE_YEAR, currentMonth);
+}
+
+function prefetchLocalData() {
+  fetch(LOCAL_DATA_URL)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText);
+      }
+      return res.json();
+    })
+    .then((json) => {
+      localPanchangam = json;
+      localDataReady = true;
+      renderCalendar(BASE_YEAR, currentMonth);
+    })
+    .catch((err) => {
+      console.warn("Failed to load local Panchangam cache", err);
+    });
+}
+
+function renderCalendar(year, month) {
+  calendarEl.innerHTML = "";
+  monthLabelEl.textContent = `${MONTHS[month]} ${year}`;
+  updateTimezoneLabel();
+
+  WEEKDAYS.forEach((day) => {
+    const header = document.createElement("div");
+    header.className = "calendar__weekday";
+    header.textContent = day;
+    calendarEl.appendChild(header);
+  });
+
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  for (let i = 0; i < firstDay; i++) {
+    const empty = document.createElement("div");
+    empty.className = "day day--empty";
+    empty.setAttribute("aria-hidden", "true");
+    calendarEl.appendChild(empty);
+  }
+
+  const festivalHighlights = [];
+  for (let date = 1; date <= daysInMonth; date++) {
+    const key = formatKey(date, month + 1, year);
+    const local = localDataReady ? localPanchangam[key] : null;
+    const festivals = festivalData[key];
+
+    const cell = document.createElement("button");
+    cell.className = "day";
+    cell.type = "button";
+    cell.setAttribute("data-date", key);
+
+    const isToday =
+      today.getFullYear() === year &&
+      today.getMonth() === month &&
+      today.getDate() === date;
+    if (isToday) {
+      cell.classList.add("day--today");
+    }
+    if (festivals) {
+      cell.classList.add("day--festival");
+      festivals.forEach((fest) => {
+        festivalHighlights.push({ day: date, name: fest });
+      });
+    }
+
+    const meta = [];
+    if (local?.tithi) {
+      meta.push(local.tithi);
+    }
+    if (local?.nakshatra || local?.nakshatram) {
+      meta.push(local.nakshatra || local.nakshatram);
+    }
+
+    cell.innerHTML = `
+      <span class="day__date">${date}</span>
+      <span class="day__meta">${meta.join(" · ")}</span>
+      ${festivals ? `<span class="day__festival">${festivals[0]}</span>` : ""}
+    `;
+
+    cell.addEventListener("click", () => showDetails(date, month + 1, year));
+    calendarEl.appendChild(cell);
+  }
+
+  updateFestivalHighlights(festivalHighlights);
+}
+
+function updateFestivalHighlights(highlights) {
+  festivalListEl.innerHTML = "";
+  if (!highlights.length) {
+    const li = document.createElement("li");
+    li.textContent = "No major festivals recorded for this month.";
+    festivalListEl.appendChild(li);
+    return;
+  }
+  highlights
+    .sort((a, b) => a.day - b.day)
+    .forEach((fest) => {
+      const li = document.createElement("li");
+      li.textContent = `${fest.day} ${MONTHS[currentMonth].slice(0, 3)} — ${fest.name}`;
+      festivalListEl.appendChild(li);
+    });
+}
+
+function formatKey(day, month, year) {
+  return `${String(day).padStart(2, "0")}-${String(month).padStart(2, "0")}-${year}`;
+}
+
+function updateTimezoneLabel() {
+  const { tz } = cities[selectedCity];
+  timezoneLabelEl.textContent = `UTC ${formatTimezoneOffset(tz)}`;
+}
+
+function formatTimezoneOffset(offset) {
+  const sign = offset >= 0 ? "+" : "-";
+  const absolute = Math.abs(offset);
+  const hours = Math.floor(absolute);
+  const minutes = Math.round((absolute - hours) * 60);
+  return `${sign}${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
 
 function renderPanchangam(data, day, month, year) {
-  const details = document.getElementById("details");
-  const nakshatra = data.nakshatra || data.nakshatram || "";
-  const rahu = data.rahu_kalam || data.rahukalam || "";
+  const key = formatKey(day, month, year);
+  const festivals = festivalData[key];
+  const title = `${MONTHS[month - 1]} ${day}, ${year}`;
 
-  details.innerHTML = `
-    <h3>${selectedCity} — ${day}-${month}-${year}</h3>
-    <p><strong>Tithi:</strong> ${data.tithi || ""}</p>
-    <p><strong>Nakshatra:</strong> ${nakshatra}</p>
-    ${rahu ? `<p><strong>Rahu Kalam:</strong> ${rahu}</p>` : ""}`;
+  const fields = [
+    { label: "Tithi", value: data.tithi },
+    { label: "Nakshatram", value: data.nakshatra || data.nakshatram },
+    { label: "Yoga", value: data.yoga },
+    { label: "Karana", value: data.karana },
+    { label: "Sunrise", value: data.sunrise },
+    { label: "Sunset", value: data.sunset },
+    { label: "Rahu Kalam", value: data.rahu_kalam || data.rahukalam },
+    { label: "Yamagandam", value: data.yamagandam },
+    { label: "Durmuhurtham", value: data.durmuhurtham || data.durmuhurtam }
+  ].filter((item) => Boolean(item.value));
+
+  const fieldMarkup = fields
+    .map(
+      (field) => `
+        <dt>${field.label}</dt>
+        <dd>${field.value}</dd>
+      `
+    )
+    .join("");
+  const fallbackMarkup = "<dt>Info</dt><dd>No Panchangam data available.</dd>";
+
+  detailsEl.innerHTML = `
+    <h3>${selectedCity}</h3>
+    <h4>${title}</h4>
+    ${festivals ? `<p class="day__festival">${festivals.join(", ")}</p>` : ""}
+    <dl>${fieldMarkup || fallbackMarkup}</dl>
+  `;
 }
 
 async function showDetails(day, month, year) {
   const { lat, lon, tz } = cities[selectedCity];
-  const details = document.getElementById("details");
-  details.innerHTML = "Loading…";
+  detailsEl.innerHTML = `<h3>${selectedCity}</h3><p>Loading Panchangam…</p>`;
+
   try {
     const response = await fetch(API_URL, {
       method: "POST",
@@ -72,31 +289,34 @@ async function showDetails(day, month, year) {
       },
       body: JSON.stringify({ day, month, year, lat, lon, tzone: tz })
     });
+
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const data = await response.json();
 
-    if (data.tithi) {
+    const data = await response.json();
+    if (data && data.tithi) {
       renderPanchangam(data, day, month, year);
       return;
     }
-    throw new Error("No data");
+    throw new Error("No Panchangam data returned from API");
   } catch (err) {
-    console.error("API fetch failed", err);
-    try {
-      const res = await fetch(LOCAL_DATA_URL);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const local = await res.json();
-      const key = `${String(day).padStart(2, "0")}-${String(month).padStart(2, "0")}-${year}`;
-      if (local[key]) {
-        renderPanchangam(local[key], day, month, year);
-      } else {
-        details.innerHTML = "No Panchangam data found.";
-      }
-    } catch (e) {
-      console.error("Local data load failed", e);
-      details.innerHTML = "Error fetching Panchangam.";
-    }
+    console.warn("API fetch failed", err);
+    fallbackToLocalData(day, month, year);
   }
 }
+
+function fallbackToLocalData(day, month, year) {
+  const key = formatKey(day, month, year);
+  if (localPanchangam[key]) {
+    renderPanchangam(localPanchangam[key], day, month, year);
+  } else {
+    detailsEl.innerHTML = `
+      <h3>${selectedCity}</h3>
+      <h4>${MONTHS[month - 1]} ${day}, ${year}</h4>
+      <p>No Panchangam data found for this date.</p>
+    `;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/start-server.bat
+++ b/start-server.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+cd /d %~dp0
+python -m http.server 8000
+endlocal

--- a/start-server.command
+++ b/start-server.command
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+python3 -m http.server 8000

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+python3 -m http.server 8000

--- a/style.css
+++ b/style.css
@@ -1,12 +1,335 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f5ff;
+  --accent: #4c1d95;
+  --accent-soft: rgba(76, 29, 149, 0.1);
+  --text: #1f2937;
+  --muted: #6b7280;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --festival: #d97706;
+}
+
+* {
+  box-sizing: border-box;
+}
 
 body {
-  font-family: Arial, sans-serif;
-  padding: 20px;
+  margin: 0;
+  font-family: "Poppins", "Noto Sans Telugu", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top, #ede9fe, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
-#calendar div {
-  margin-bottom: 20px;
+
+.hero {
+  padding: 2.5rem clamp(1rem, 4vw, 3rem);
+  background: linear-gradient(120deg, rgba(76, 29, 149, 0.85), rgba(59, 130, 246, 0.8)), url('https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=1400&q=80') center/cover;
+  color: #fff;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+  box-shadow: 0 10px 30px rgba(76, 29, 149, 0.25);
 }
-button {
-  margin: 2px;
-  padding: 5px 10px;
+
+.hero__content {
+  flex: 1 1 280px;
+}
+
+.hero__content h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.hero__content p {
+  margin: 0;
+  max-width: 480px;
+  line-height: 1.5;
+}
+
+.hero__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.control,
+.month-nav button {
+  font: inherit;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.control:hover,
+.month-nav button:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+#citySelect {
+  min-width: 200px;
+}
+
+.month-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.month-nav h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+#timezoneLabel {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.calendar-panel {
+  background: var(--card);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.legend {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot--today {
+  background: var(--accent);
+}
+
+.dot--festival {
+  background: var(--festival);
+}
+
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.calendar__weekday {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.day {
+  min-height: 110px;
+  background: var(--accent-soft);
+  border-radius: 18px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: 1px solid transparent;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border 0.15s ease;
+  cursor: pointer;
+  text-align: left;
+}
+
+.day:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(76, 29, 149, 0.15);
+  border-color: rgba(76, 29, 149, 0.3);
+}
+
+.day__date {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.day__meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.day__festival {
+  color: var(--festival);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.day--empty {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.day--today {
+  border: 2px solid var(--accent);
+  background: rgba(76, 29, 149, 0.15);
+}
+
+.day--festival {
+  background: rgba(217, 119, 6, 0.15);
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.1);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.35rem;
+}
+
+.card p,
+.card li {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+#details h4 {
+  margin-bottom: 0.25rem;
+  color: var(--text);
+}
+
+#details dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+#details dt {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+#details dd {
+  margin: 0;
+  color: var(--text);
+}
+
+#festivalList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+#festivalList li {
+  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(217, 119, 6, 0.12);
+  color: var(--festival);
+  font-weight: 500;
+}
+
+.footer {
+  text-align: center;
+  padding: 1.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .info-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero__controls {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .month-nav {
+    justify-content: space-between;
+  }
+
+  .calendar {
+    gap: 0.5rem;
+  }
+
+  .day {
+    min-height: 90px;
+    padding: 0.6rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add double-click start scripts for Windows, macOS, and Linux to launch the local calendar server
- update the README with a step-by-step quick start guide for running the site without coding knowledge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690927966c48832b93c2b19b6b92da38